### PR TITLE
Bug: App Position with Second Screen

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,13 +1,30 @@
 // Modules to control application life and create native browser window
 const {app, BrowserWindow} = require('electron')
+const windowStateKeeper = require('electron-window-state')
 
 // Keep a global reference of the window object, if you don't, the window will
 // be closed automatically when the JavaScript object is garbage collected.
 let mainWindow
 
 function createWindow () {
+  // Load the previous state with fallback to defaults
+  let mainWindowState = windowStateKeeper({
+    defaultWidth: 1000,
+    defaultHeight: 800
+  })
+
   // Create the browser window.
-  mainWindow = new BrowserWindow({width: 800, height: 600})
+  mainWindow = new BrowserWindow({
+    'x': mainWindowState.x,
+    'y': mainWindowState.y,
+    'width': mainWindowState.width,
+    'height': mainWindowState.height
+  })
+
+  // Let us register listeners on the window, so we can update the state
+  // automatically (the listeners will be removed when the window is closed)
+  // and restore the maximized or full screen state
+  mainWindowState.manage(mainWindow)
 
   // and load the index.html of the app.
   mainWindow.loadFile('index.html')

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,11 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "deep-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -262,6 +267,16 @@
         "rc": "^1.2.1",
         "semver": "^5.4.1",
         "sumchecker": "^2.0.2"
+      }
+    },
+    "electron-window-state": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/electron-window-state/-/electron-window-state-5.0.2.tgz",
+      "integrity": "sha512-fcSS+ZxfY8K14Ig7XI0/PHZ54wBr1LEPEgMTRlFn799xDQJ9UsP8Ti+NNb7JhvRaJBsL7MWvtY6vWBk4BpVfMw==",
+      "requires": {
+        "deep-equal": "^1.0.1",
+        "jsonfile": "^4.0.0",
+        "mkdirp": "^0.5.1"
       }
     },
     "env-paths": {
@@ -408,8 +423,7 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
-      "dev": true
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "har-schema": {
       "version": "2.0.0",
@@ -550,7 +564,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -639,7 +652,6 @@
       "version": "0.5.1",
       "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -647,8 +659,7 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,5 +18,8 @@
   "license": "CC0-1.0",
   "devDependencies": {
     "electron": "^3.0.4"
+  },
+  "dependencies": {
+    "electron-window-state": "^5.0.2"
   }
 }


### PR DESCRIPTION
## About

Related:
- https://github.com/mawie81/electron-window-state/issues/44
- https://github.com/mawie81/electron-window-state/pull/45

See
- https://github.com/mawie81/electron-window-state/issues/1
- https://github.com/mawie81/electron-window-state/issues/4
- https://github.com/mawie81/electron-window-state/issues/27
- https://github.com/mawie81/electron-window-state/issues/31
- https://github.com/mawie81/electron-window-state/issues/38
- https://github.com/mawie81/electron-window-state/issues/43

## Clone
```
git clone -b bug/electron-window-state-second-screen https://github.com/MathieuDebit/electron-quick-start.git
cd electron-quick-start
npm install
npm start
```

## How to Reproduce
### Windows 10
- Start and move the app on the second screen
- Close the app
- Unplug second screen
- Start the app
→ The app is started, visible in Dock and Task Manager, but main window is not visible
- Plug the second screen
→ The app is visible and displayed at the previous position