### PR TITLE
Bug: Window not positioned correctly when using setPosition() with two displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,10 +11,23 @@
     Chromium <script>document.write(process.versions.chrome)</script>,
     and Electron <script>document.write(process.versions.electron)</script>.
 
-    <div>
+    <fieldset>
+      <legend>Screens</legend>
+      <em>Open console for more info</em>
+
+      <div id="screensContainer"></div>
+    </fieldset>
+
+    <fieldset>
+      <legend>Position</legend>
+
+      <label>Position:</label>
+      <input type="number" range="1" id="positionX" value="0">
+      <input type="number" range="1" id="positionY" value="0">
+
       <button id="resetPositionButton">Reset position</button>
       <p>Position at reset was: <span id="positionInfo"></span></p>
-    </div>
+    </fieldset>
 
     <script>
       // You can also require other files to run in this process

--- a/index.html
+++ b/index.html
@@ -11,6 +11,11 @@
     Chromium <script>document.write(process.versions.chrome)</script>,
     and Electron <script>document.write(process.versions.electron)</script>.
 
+    <div>
+      <button id="resetPositionButton">Reset position</button>
+      <p>Position at reset was: <span id="positionInfo"></span></p>
+    </div>
+
     <script>
       // You can also require other files to run in this process
       require('./renderer.js')

--- a/renderer.js
+++ b/renderer.js
@@ -1,3 +1,12 @@
 // This file is required by the index.html file and will
 // be executed in the renderer process for that window.
 // All of the Node.js APIs are available in this process.
+
+const mainWindow = require('electron').remote.getCurrentWindow();
+const resetPositionButton = document.getElementById('resetPositionButton');
+const positionInfo = document.getElementById('positionInfo');
+
+resetPositionButton.onclick = () => {
+  mainWindow.setPosition(0, 0);
+  positionInfo.innerHTML = mainWindow.getPosition();
+};

--- a/renderer.js
+++ b/renderer.js
@@ -3,10 +3,22 @@
 // All of the Node.js APIs are available in this process.
 
 const mainWindow = require('electron').remote.getCurrentWindow();
+const screen = require('electron').screen;
+
+const screensContainer = document.getElementById('screensContainer');
 const resetPositionButton = document.getElementById('resetPositionButton');
 const positionInfo = document.getElementById('positionInfo');
+const positionX = document.getElementById('positionX');
+const positionY = document.getElementById('positionY');
+
+screen.getAllDisplays().map(display => {
+  console.log(display);
+  const elem = document.createElement('div');
+  elem.innerHTML = JSON.stringify(display.bounds);
+  screensContainer.appendChild(elem);
+});
 
 resetPositionButton.onclick = () => {
-  mainWindow.setPosition(0, 0);
+  mainWindow.setPosition(Number(positionX.value), Number(positionY.value));
   positionInfo.innerHTML = mainWindow.getPosition();
 };


### PR DESCRIPTION
See https://github.com/electron/electron/issues/15851

**To Reproduce**
```sh
$ git clone https://github.com/MathieuDebit/electron-quick-start.git -b bug/window-set-position
$ npm install
$ npm start || electron .
```

- Move window to second screen
- Click on `resetPosition` with position `0, 0`
→ Depending on the second screen virtual position, the window is not correctly positioned.

**Additional Information**
MacOS seems to handle off-screen window differently so the bug is not always present (see https://github.com/mawie81/electron-window-state/issues/44#issuecomment-438381017)
